### PR TITLE
Fix errant comma for npm install parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An AngularJS service and a directive to quickly use the HTML5 fullscreen API",
   "license": "MIT",
   "author": {
-    "name": "obscure-web",
+    "name": "obscure-web"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Prior to implementing the change below, running `npm install` by pointing to the git repository resulted in the following error:

> $ npm install ./angular-fullscreen-fixed
> npm ERR! Unexpected token } in JSON at position 222

Looks like this was extraneous after removing the email when forking from the original repository.